### PR TITLE
Pull all castles in one operation

### DIFF
--- a/lib/homesick.rb
+++ b/lib/homesick.rb
@@ -64,6 +64,7 @@ class Homesick < Thor
   def pull(name="")
     if options[:all]
       inside_each_castle do |castle|
+        shell.say castle.to_s.gsub(repos_dir.to_s + '/', '') + ':'
         update_castle castle
       end
     else


### PR DESCRIPTION
I wanted an --all option for pull that would update all my castles in one go, so here's my stab at implementing it.  c870bfe4 and c3999f92 implement this functionality. The third commit is something I'm not yet totally sure about but threw in there anyway: it limits the concept of "castle" so that git repos inside other git repos (like submodules of a castle) are not considered. I.e. if there are castles "a" and "b" and "b" has a submodule "bb", commands like "homesick list" will only list "a" and "b", not "bb".
