### PR TITLE
support castle files not starting with a '.'.

### DIFF
--- a/lib/homesick.rb
+++ b/lib/homesick.rb
@@ -83,11 +83,12 @@ class Homesick < Thor
     check_castle_existance(name, "symlink")
 
     inside castle_dir(name) do
-      files = Pathname.glob('.*').reject{|a| [".",".."].include?(a.to_s)}
+      files = Pathname.glob('{.*,*}').reject{|a| [".",".."].include?(a.to_s)}
       files.each do |path|
         absolute_path = path.expand_path
 
         inside home_dir do
+          path = Pathname.new(".#{path}") if path.to_s[0] != '.'
           adjusted_path = (home_dir + path).basename
 
           ln_s absolute_path, adjusted_path
@@ -101,7 +102,7 @@ class Homesick < Thor
     castle = Pathname.new(castle)
     file = Pathname.new(file)
     check_castle_existance(castle, 'track')
-    
+
     absolute_path = file.expand_path
     castle_path = castle_dir(castle)
     mv absolute_path, castle_path


### PR DESCRIPTION
For example: castle/home/ackrc will get symlinked as ~/.ackrc -> ~/.homesick/repos/dotfiles/home/ackrc

This makes it easier to edit castles in TextMate, and browse them in finder and/or other programs that do not show dot files by default.

This shouldn't break the current functionality.
