### PR TITLE
enable recursive submodule

### DIFF
--- a/lib/homesick/actions.rb
+++ b/lib/homesick/actions.rb
@@ -51,7 +51,7 @@ class Homesick
 
     def git_submodule_update(config = {})
       say_status 'git submodule', 'update', :green unless options[:quiet]
-      system "git submodule --quiet update >/dev/null 2>&1" unless options[:pretend]
+      system "git submodule --quiet update --init --recursive >/dev/null 2>&1" unless options[:pretend]
     end
 
     def git_pull(config = {})


### PR DESCRIPTION
If dotfiles repository has nested submodules, current version homesick can only update first depth. But --init and --recursive option of git submodule update enable init and update all nested submodules.
