### PR TITLE
Use File::FNM_DOTMATCH when searching for .git dirs

### DIFF
--- a/lib/homesick.rb
+++ b/lib/homesick.rb
@@ -181,7 +181,7 @@ class Homesick < Thor
   end
 
   def all_castles
-    dirs = Pathname.glob("#{repos_dir}/**/*/.git")
+    dirs = Pathname.glob("#{repos_dir}/**/*/.git", File::FNM_DOTMATCH)
     # reject paths that lie inside another castle, like git submodules
     return dirs.reject do |dir|
       dirs.any? {|other| dir != other && dir.fnmatch(other.parent.join('*').to_s) }


### PR DESCRIPTION
Fix for `homesick list` in ruby 2.0.0-p0
