### PR TITLE
Fixes glob to work with 2.0.0

### DIFF
--- a/lib/homesick.rb
+++ b/lib/homesick.rb
@@ -124,7 +124,7 @@ class Homesick < Thor
       home_path = home_dir + file
       ln_s absolute_path, home_path
     end
-    
+
     inside castle_path do
       git_add absolute_path
     end
@@ -181,7 +181,7 @@ class Homesick < Thor
   end
 
   def all_castles
-    dirs = Pathname.glob("#{repos_dir}/**/*/.git")
+    dirs = Pathname.glob("#{repos_dir}/**/.git", File::FNM_DOTMATCH)
     # reject paths that lie inside another castle, like git submodules
     return dirs.reject do |dir|
       dirs.any? {|other| dir != other && dir.fnmatch(other.parent.join('*').to_s) }
@@ -205,7 +205,7 @@ class Homesick < Thor
       git_submodule_update
     end
   end
-  
+
   def commit_castle(castle)
     check_castle_existance(castle, "commit")
     inside repos_dir.join(castle) do


### PR DESCRIPTION
homesick list fails on ruby 2.0.0-rc2, I think because they fixed this
bug: https://bugs.ruby-lang.org/issues/6977, changing the way recursive
globs work. Test case:

``` ruby
require "homesick"
require "pathname"

repos = Homesick.new.send :repos_dir

Dir.glob("#{repos}/**/*/.git") # => []

Dir.glob("#{repos}/**/*/.git", File::FNM_DOTMATCH) # => ["/home/eric/.homesick/repos/dotfiles/.git"]

```

This change, however, then broke 1.9.3, but removing the extra "/*"
works on both 1.9 and 2.0.

Your spec for `homesick list` fails on 2.0, and passes with my change, so it was not necessary to write an additional test.
