### PR TITLE
Remove .git suffix on destination directory if URL ends with it.

### DIFF
--- a/lib/homesick/actions.rb
+++ b/lib/homesick/actions.rb
@@ -3,10 +3,7 @@ class Homesick
     # TODO move this to be more like thor's template, empty_directory, etc
     def git_clone(repo, config = {})
       config ||= {}
-      destination = config[:destination] || begin
-        repo =~ /([^\/]+)(?:\.git)?$/
-       $1
-      end
+      destination = config[:destination] || File.basename(repo, '.git')
 
       destination = Pathname.new(destination) unless destination.kind_of?(Pathname)
       FileUtils.mkdir_p destination.dirname

--- a/spec/homesick_spec.rb
+++ b/spec/homesick_spec.rb
@@ -39,6 +39,14 @@ describe "homesick" do
       end
     end
 
+    it "should clone git repo like file:///path/to.git" do
+      bare_repo = File.join(create_construct.to_s, "dotfiles.git")
+      system "git init --bare #{bare_repo} >/dev/null 2>&1"
+
+      homesick.clone "file://#{bare_repo}"
+      File.directory?(File.join(home.to_s, '.homesick/repos/dotfiles')).should be_true
+    end
+
     it "should clone git repo like git://host/path/to.git" do
       homesick.should_receive(:git_clone).with('git://github.com/technicalpickles/pickled-vim.git')
 


### PR DESCRIPTION
Hey there,

I ran into an issue when managing some pull requests in my [Homesick Chef cookbook](https://github.com/fnichol/chef-homesick). It looks like for Homesick gem versions greater than 0.7.0 Git URLs ending in `.git` will retain the suffix when the castle directory is created. I believe the regression was introduced by https://github.com/technicalpickles/homesick/commit/376fd88fc956885fb41587c7e70c097e54b174b8.

This pull request cleans up the change in behavior and adds a sanity spec to cover future refactorings.

For example, the following:

```
homesick clone git://github.com/technicalpickles/pickled-vim.git
```

should produce a castle directory of:

```
$HOME/.homesick/repos/pickled-vim
```

Thanks for homesick, essential sanity for me when spinning up new systems :smile: 
