### PR TITLE
Files with parentheses in filename fail to symlink/track

### DIFF
--- a/lib/homesick/actions.rb
+++ b/lib/homesick/actions.rb
@@ -68,7 +68,7 @@ class Homesick
 
     def git_add(file, config = {})
       say_status 'git add file', '', :green unless options[:quiet]
-      system "git add #{file}" unless options[:pretend]
+      system "git add '#{file}'" unless options[:pretend]
     end
 
     def git_status(config = {})
@@ -89,11 +89,11 @@ class Homesick
         say_status :conflict, "#{destination} exists", :red unless options[:quiet]
 
         if options[:force] || shell.file_collision(destination) { source }
-          system "mv #{source} #{destination}" unless options[:pretend]
+          system "mv '#{source}' '#{destination}'" unless options[:pretend]
         end
       else
         # this needs some sort of message here.
-        system "mv #{source} #{destination}" unless options[:pretend]
+        system "mv '#{source}' '#{destination}'" unless options[:pretend]
       end
     end
 
@@ -120,19 +120,19 @@ class Homesick
           say_status :conflict, "#{destination} exists and points to #{destination.readlink}", :red unless options[:quiet]
 
           if options[:force] || shell.file_collision(destination) { source }
-            system "ln -nsf #{source} #{destination}" unless options[:pretend]
+            system "ln -nsf '#{source}' '#{destination}'" unless options[:pretend]
           end
         end
       elsif destination.exist?
         say_status :conflict, "#{destination} exists", :red unless options[:quiet]
 
         if options[:force] || shell.file_collision(destination) { source }
-          system "rm -rf #{destination}" unless options[:pretend]
-          system "ln -sf #{source} #{destination}" unless options[:pretend]
+          system "rm -rf '#{destination}'" unless options[:pretend]
+          system "ln -sf '#{source}' '#{destination}'" unless options[:pretend]
         end
       else
         say_status :symlink, "#{source.expand_path} to #{destination.expand_path}", :green unless options[:quiet]
-        system "ln -s #{source} #{destination}" unless options[:pretend]
+        system "ln -s '#{source}' '#{destination}'" unless options[:pretend]
       end
     end
   end

--- a/spec/homesick_spec.rb
+++ b/spec/homesick_spec.rb
@@ -397,6 +397,19 @@ describe 'homesick' do
       some_rc_file.readlink.should == tracked_file
     end
 
+    it 'should handle files with parens' do
+      castle = given_castle('castle_repo')
+
+      some_rc_file = home.file 'Default (Linux).sublime-keymap'
+
+      homesick.track(some_rc_file.to_s, 'castle_repo')
+
+      tracked_file = castle.join('Default (Linux).sublime-keymap')
+      tracked_file.should exist
+
+      some_rc_file.readlink.should == tracked_file
+    end
+
     it 'should track a file in nested folder structure' do
       castle = given_castle('castle_repo')
 


### PR DESCRIPTION
I want to track my Sublime Text keybindings.  They're in `~/.config/sublime-text-3/Packages/User/Default (Linux).sublime-keymap`.  When you try to `homesick track` that file, you get:

```
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `mv /home/cpence/.config/sublime-text-3/Packages/User/Default (Linux).sublime-keymap /home/cpence/.homesick/repos/dotfiles/home/.config/sublime-text-3/Packages/User/Default (Linux).sublime-keymap'
    conflict  /home/cpence/.config/sublime-text-3/Packages/User/Default (Linux).sublime-keymap exists
Overwrite /home/cpence/.config/sublime-text-3/Packages/User/Default (Linux).sublime-keymap? (enter "h" for help) [Ynaqdh]
```

And if you copy it yourself and then try to `homesick symlink`, you get:

```
     symlink  /home/cpence/.homesick/repos/dotfiles/home/.config/sublime-text-3/Packages/User/Default (Linux).sublime-keymap to /home/cpence/.config/sublime-text-3/Packages/User/Default (Linux).sublime-keymap
sh: -c: line 0: syntax error near unexpected token `('
sh: -c: line 0: `ln -s /home/cpence/.homesick/repos/dotfiles/home/.config/sublime-text-3/Packages/User/Default (Linux).sublime-keymap /home/cpence/.config/sublime-text-3/Packages/User/Default (Linux).sublime-keymap'
```

Looks like some of the embedded calls to `sh` aren't quoting their arguments properly, or aren't escaping parentheses.
