### PR TITLE
Remove symlink shorthand note in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,9 +27,6 @@ With the castle cloned, you can now link its contents into your home dir:
 
     homesick symlink pickled-vim
 
-If you use the shorthand syntax for GitHub repositories in your clone, please note you will instead need to run:
-
-    homesick symlink technicalpickles/pickled-vim
 
 You can remove symlinks anytime when you don't need them anymore
 


### PR DESCRIPTION
Seems that using `homesick symlink <username>/<reponame>` after a clone does not locate the directory properly. `homesick symlink <reponame>` works in both cases regardless if the shorthand or full git url was used to clone.
