### PR TITLE
Git clone now uses config push.default upstream

### DIFF
--- a/lib/homesick/actions.rb
+++ b/lib/homesick/actions.rb
@@ -10,7 +10,7 @@ class Homesick
 
       if ! destination.directory?
         say_status 'git clone', "#{repo} to #{destination.expand_path}", :green unless options[:quiet]
-        system "git clone -q --recursive #{repo} #{destination}" unless options[:pretend]
+        system "git clone -q --config push.default=upstream --recursive #{repo} #{destination}" unless options[:pretend]
       else
         say_status :exist, destination.expand_path, :blue unless options[:quiet]
       end


### PR DESCRIPTION
This should fix https://github.com/technicalpickles/homesick/issues/54 by adding the local configuration setting `push.default=upstream` when cloning. I used `upstream` instead of `simple` because the `simple` option breaks users using git version < 1.7.11.
