### PR TITLE
Check for git before all relevant homesick commands

### DIFF
--- a/lib/homesick.rb
+++ b/lib/homesick.rb
@@ -21,6 +21,7 @@ class Homesick < Thor
 
   desc 'clone URI', 'Clone +uri+ as a castle for homesick'
   def clone(uri)
+    which_check 'git'
     inside repos_dir do
       destination = nil
       if File.exist?(uri)
@@ -137,6 +138,7 @@ class Homesick < Thor
 
   desc 'track FILE CASTLE', 'add a file to a castle'
   def track(file, castle = DEFAULT_CASTLE_NAME)
+    which_check 'git'
     castle = Pathname.new(castle)
     file = Pathname.new(file.chomp('/'))
     check_castle_existance(castle, 'track')
@@ -180,6 +182,7 @@ class Homesick < Thor
 
   desc 'list', 'List cloned castles'
   def list
+    which_check 'git'
     inside_each_castle do |castle|
       say_status castle.relative_path_from(repos_dir).to_s, `git config remote.origin.url`.chomp, :cyan
     end
@@ -187,6 +190,7 @@ class Homesick < Thor
 
   desc 'status CASTLE', 'Shows the git status of a castle'
   def status(castle = DEFAULT_CASTLE_NAME)
+    which_check 'git'
     check_castle_existance(castle, 'status')
     inside repos_dir.join(castle) do
       git_status
@@ -195,6 +199,7 @@ class Homesick < Thor
 
   desc 'diff CASTLE', 'Shows the git diff of uncommitted changes in a castle'
   def diff(castle = DEFAULT_CASTLE_NAME)
+    which_check 'git'
     check_castle_existance(castle, 'diff')
     inside repos_dir.join(castle) do
       git_diff
@@ -209,6 +214,7 @@ class Homesick < Thor
 
   desc 'generate PATH', 'generate a homesick-ready git repo at PATH'
   def generate(castle)
+    which_check 'git'
     castle = Pathname.new(castle).expand_path
 
     github_user = `git config github.user`.chomp
@@ -270,6 +276,7 @@ class Homesick < Thor
   end
 
   def update_castle(castle)
+    which_check 'git'
     check_castle_existance(castle, 'pull')
     inside repos_dir.join(castle) do
       git_pull
@@ -279,6 +286,7 @@ class Homesick < Thor
   end
 
   def commit_castle(castle)
+    which_check 'git'
     check_castle_existance(castle, 'commit')
     inside repos_dir.join(castle) do
       git_commit_all
@@ -286,6 +294,7 @@ class Homesick < Thor
   end
 
   def push_castle(castle)
+    which_check 'git'
     check_castle_existance(castle, 'push')
     inside repos_dir.join(castle) do
       git_push
@@ -308,6 +317,7 @@ class Homesick < Thor
   end
 
   def subdir_add(castle, path)
+    which_check 'git'
     subdir_filepath = subdir_file(castle)
     File.open(subdir_filepath, 'a+') do |subdir|
       subdir.puts path unless subdir.readlines.reduce(false) do |memo, line|
@@ -321,6 +331,7 @@ class Homesick < Thor
   end
 
   def subdir_remove(castle, path)
+    which_check 'git'
     subdir_filepath = subdir_file(castle)
     if subdir_filepath.exist?
       lines = IO.readlines(subdir_filepath).delete_if { |line| line == "#{path}\n" }

--- a/lib/homesick/actions.rb
+++ b/lib/homesick/actions.rb
@@ -81,6 +81,11 @@ class Homesick
       system "git diff" unless options[:pretend]
     end
 
+    def which_check(command)
+      installed = system "which #{command} 2>&1 >/dev/null"
+      say_status :error, "Could not find #{command}, expected #{command} to be installed", :red and exit unless installed
+    end
+
     def mv(source, destination, config = {})
       source = Pathname.new(source)
       destination = Pathname.new(destination + source.basename)


### PR DESCRIPTION
To close #25 I've added a small method to run before git-related homesick commands, which was [originally suggested](https://github.com/technicalpickles/homesick/issues/25#issuecomment-11175658) by @technicalpickles.

I was originally going to insert this into the git-specific functions (`git_clone`, `git_diff`, `git status`, etc), but it would be more expensive [in scenarios that have multiple git commands](https://github.com/christianbundy/homesick/blob/1e70386f5bafc1ea8d9a27fe5c2b3813e51c40d5/lib/homesick.rb#L51), as well as scenarios where git isn't called until the end of the function (which could have all sorts of side effects).
