### PR TITLE
Test with Ruby 2.1.0 on Travis and add it to the supported Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
+  - 2.1.0
   - 2.0.0
   - 1.9.3

--- a/README.markdown
+++ b/README.markdown
@@ -156,6 +156,7 @@ Homesick is tested on the following Ruby versions:
 
 * 1.9.3
 * 2.0.0
+* 2.1.0
 
 ## Note on Patches/Pull Requests
  


### PR DESCRIPTION
## Changes
- Test with Ruby 2.1.0 on Travis.
- Add Ruby 2.1.0 to the supported Rubies in the readme.
## Related posts
- [Ruby 2.1.0 is released](https://www.ruby-lang.org/en/news/2013/12/25/ruby-2-1-0-is-released/)
- [Support for Ruby version 1.9.3 will end on February 23, 2015.](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/)
