### PR TITLE
Remove duplicate methods rm and rm_link

### DIFF
--- a/lib/homesick/actions.rb
+++ b/lib/homesick/actions.rb
@@ -102,22 +102,6 @@ class Homesick
       end
     end
 
-    def rm_link(target)
-      target = Pathname.new(target)
-
-      if target.symlink?
-        say_status :unlink, "#{target.expand_path}", :green unless options[:quiet]
-        FileUtils.rm_rf target
-      else
-        say_status :conflict, "#{target} is not a symlink", :red unless options[:quiet]
-      end
-    end
-
-    def rm(file)
-      say_status "rm #{file}", '', :green unless options[:quiet]
-      system "rm #{file}" if File.exists?(file)
-    end
-
     def rm_rf(dir)
       say_status "rm -rf #{dir}", '', :green unless options[:quiet]
       system "rm -rf #{dir}"
@@ -136,7 +120,7 @@ class Homesick
 
     def rm(file)
       say_status "rm #{file}", '', :green unless options[:quiet]
-      system "rm #{file}"
+      system "rm #{file}" if File.exists?(file)
     end
 
     def rm_r(dir)


### PR DESCRIPTION
You can run this command to see the issue as reported by `rspec -w`:
`rspec -wf doc 2>&1 | grep ".*homesick.*warning:.*"`
