### PR TITLE
Renamed symlink command to link.

### DIFF
--- a/lib/homesick.rb
+++ b/lib/homesick.rb
@@ -19,6 +19,8 @@ class Homesick < Thor
 
   map '-v' => :version
   map '--version' => :version
+  # Retain a mapped version of the symlink command for compatibility.
+  map 'symlink' => :link
 
   def initialize(args = [], options = {}, config = {})
     super
@@ -123,9 +125,9 @@ class Homesick < Thor
     end
   end
 
-  desc 'symlink CASTLE', 'Symlinks all dotfiles from the specified castle'
+  desc 'link CASTLE', 'Symlinks all dotfiles from the specified castle'
   method_option :force, :default => false, :desc => 'Overwrite existing conflicting symlinks without prompting.'
-  def symlink(name = DEFAULT_CASTLE_NAME)
+  def link(name = DEFAULT_CASTLE_NAME)
     check_castle_existance(name, 'symlink')
 
     inside castle_dir(name) do

--- a/spec/homesick_spec.rb
+++ b/spec/homesick_spec.rb
@@ -145,13 +145,13 @@ describe 'homesick' do
     end
   end
 
-  describe 'symlink' do
+  describe 'link' do
     let(:castle) { given_castle('glencairn') }
 
     it 'links dotfiles from a castle to the home folder' do
       dotfile = castle.file('.some_dotfile')
 
-      homesick.symlink('glencairn')
+      homesick.link('glencairn')
 
       home.join('.some_dotfile').readlink.should == dotfile
     end
@@ -159,7 +159,7 @@ describe 'homesick' do
     it 'links non-dotfiles from a castle to the home folder' do
       dotfile = castle.file('bin')
 
-      homesick.symlink('glencairn')
+      homesick.link('glencairn')
 
       home.join('bin').readlink.should == dotfile
     end
@@ -174,7 +174,7 @@ describe 'homesick' do
 
         dotdir = castle.directory('.vim')
 
-        homesick.symlink('glencairn')
+        homesick.link('glencairn')
 
         existing_dotdir_link.readlink.should == dotdir
       end
@@ -184,7 +184,7 @@ describe 'homesick' do
 
         dotdir = castle.directory('.vim')
 
-        homesick.symlink('glencairn')
+        homesick.link('glencairn')
 
         existing_dotdir.readlink.should == dotdir
       end
@@ -196,7 +196,7 @@ describe 'homesick' do
         dotdir = castle.directory('.config')
         dotfile = dotdir.file('.some_dotfile')
 
-        homesick.symlink('glencairn')
+        homesick.link('glencairn')
 
         home_dotdir = home.join('.config')
         home_dotdir.symlink?.should be == false
@@ -210,7 +210,7 @@ describe 'homesick' do
         dotdir = castle.directory('.config').directory('appA')
         dotfile = dotdir.file('.some_dotfile')
 
-        homesick.symlink('glencairn')
+        homesick.link('glencairn')
 
         home_dotdir = home.join('.config').join('appA')
         home_dotdir.symlink?.should be == false
@@ -226,7 +226,7 @@ describe 'homesick' do
         someapp_dir = config_dir.directory('someapp')
         someapp_dotfile = someapp_dir.file('.some_appfile')
 
-        homesick.symlink('glencairn')
+        homesick.link('glencairn')
 
         home_config_dir = home.join('.config')
         home_someapp_dir = home_config_dir.join('someapp')
@@ -242,7 +242,7 @@ describe 'homesick' do
       it 'using default castle name: "dotfiles"' do
         dotfile = castle.file('.some_dotfile')
 
-        homesick.symlink
+        homesick.link
 
         home.join('.some_dotfile').readlink.should == dotfile
       end
@@ -255,7 +255,7 @@ describe 'homesick' do
     it 'unlinks dotfiles in the home folder' do
       castle.file('.some_dotfile')
 
-      homesick.symlink('glencairn')
+      homesick.link('glencairn')
       homesick.unlink('glencairn')
 
       home.join('.some_dotfile').should_not exist
@@ -264,7 +264,7 @@ describe 'homesick' do
     it 'unlinks non-dotfiles from the home folder' do
       castle.file('bin')
 
-      homesick.symlink('glencairn')
+      homesick.link('glencairn')
       homesick.unlink('glencairn')
 
       home.join('bin').should_not exist
@@ -276,7 +276,7 @@ describe 'homesick' do
       it 'can unlink sub directories' do
         castle.directory('.config').file('.some_dotfile')
 
-        homesick.symlink('glencairn')
+        homesick.link('glencairn')
         homesick.unlink('glencairn')
 
         home_dotdir = home.join('.config')
@@ -291,7 +291,7 @@ describe 'homesick' do
       it 'can unsymlink in nested sub directory' do
         castle.directory('.config').directory('appA').file('.some_dotfile')
 
-        homesick.symlink('glencairn')
+        homesick.link('glencairn')
         homesick.unlink('glencairn')
 
         home_dotdir = home.join('.config').join('appA')
@@ -308,7 +308,7 @@ describe 'homesick' do
         config_dir.file('.some_dotfile')
         config_dir.directory('someapp').file('.some_appfile')
 
-        homesick.symlink('glencairn')
+        homesick.link('glencairn')
         homesick.unlink('glencairn')
 
         home_config_dir = home.join('.config')
@@ -326,7 +326,7 @@ describe 'homesick' do
       it 'using default castle name: "dotfiles"' do
         castle.file('.some_dotfile')
 
-        homesick.symlink
+        homesick.link
         homesick.unlink
 
         home.join('.some_dotfile').should_not exist


### PR DESCRIPTION
I thought I'd have a quick go at this after having a look at #62. I've renamed the 'symlink' command to 'link' and have edited the tests so they continue to pass. I've also mapped the command 'symlink' to 'link' so that it will continue to work for anyone who uses it.
