### PR TITLE
Improve the handling of homes that are symlinked

### DIFF
--- a/lib/homesick.rb
+++ b/lib/homesick.rb
@@ -285,7 +285,8 @@ class Homesick < Thor
   protected
 
   def home_dir
-    @home_dir ||= Pathname.new(ENV['HOME'] || '~').expand_path
+    # Use realpath instead of expand_path to cover cases where $HOME is a symlink
+    @home_dir ||= Pathname.new(ENV['HOME'] || '~').realpath
   end
 
   def repos_dir


### PR DESCRIPTION
Given that the code uses castle_dir.realpath for checks, using expand_path for home_dir can cause unexpected results in cases the home directory includes a symlink (eg. /home -> /usr/home).

Fixes #86
