### PR TITLE
Edits to keep code DRY

### DIFF
--- a/lib/homesick/actions/file_actions.rb
+++ b/lib/homesick/actions/file_actions.rb
@@ -8,7 +8,7 @@ module Homesick
         destination = Pathname.new(destination + source.basename)
 
         if destination.exist?
-          say_status :conflict, "#{destination} exists", :red unless options[:quiet]
+          say_status :conflict, "#{destination} exists", :red
 
           FileUtils.mv source, destination if (options[:force] || shell.file_collision(destination) { source }) && !options[:pretend]
         else
@@ -18,7 +18,7 @@ module Homesick
       end
 
       def rm_rf(dir)
-        say_status "rm -rf #{dir}", '', :green unless options[:quiet]
+        say_status "rm -rf #{dir}", '', :green
         FileUtils.rm_r dir, force: true
       end
 
@@ -26,20 +26,20 @@ module Homesick
         target = Pathname.new(target)
 
         if target.symlink?
-          say_status :unlink, "#{target.expand_path}", :green unless options[:quiet]
+          say_status :unlink, "#{target.expand_path}", :green
           FileUtils.rm_rf target
         else
-          say_status :conflict, "#{target} is not a symlink", :red unless options[:quiet]
+          say_status :conflict, "#{target} is not a symlink", :red
         end
       end
 
       def rm(file)
-        say_status "rm #{file}", '', :green unless options[:quiet]
+        say_status "rm #{file}", '', :green
         FileUtils.rm file, force: true
       end
 
       def rm_r(dir)
-        say_status "rm -r #{dir}", '', :green unless options[:quiet]
+        say_status "rm -r #{dir}", '', :green
         FileUtils.rm_r dir
       end
 
@@ -64,16 +64,16 @@ module Homesick
       def handle_symlink_action(action, source, destination)
         case action
         when :identical
-          say_status :identical, destination.expand_path, :blue unless options[:quiet]
+          say_status :identical, destination.expand_path, :blue
         when :symlink_conflict
           say_status :conflict,
                      "#{destination} exists and points to #{destination.readlink}",
-                     :red unless options[:quiet]
+                     :red
 
           FileUtils.rm destination
           FileUtils.ln_s source, destination, force: true unless options[:pretend]
         when :conflict
-          say_status :conflict, "#{destination} exists", :red unless options[:quiet]
+          say_status :conflict, "#{destination} exists", :red
 
           if collision_accepted?
             FileUtils.rm_r destination, force: true unless options[:pretend]
@@ -82,7 +82,7 @@ module Homesick
         else
           say_status :symlink,
                      "#{source.expand_path} to #{destination.expand_path}",
-                     :green unless options[:quiet]
+                     :green
           FileUtils.ln_s source, destination unless options[:pretend]
         end
       end

--- a/lib/homesick/actions/git_actions.rb
+++ b/lib/homesick/actions/git_actions.rb
@@ -12,12 +12,12 @@ module Homesick
         FileUtils.mkdir_p destination.dirname
 
         if destination.directory?
-          say_status :exist, destination.expand_path, :blue unless options[:quiet]
+          say_status :exist, destination.expand_path, :blue
         else
           say_status 'git clone',
                      "#{repo} to #{destination.expand_path}",
-                     :green unless options[:quiet]
-          system "git clone -q --config push.default=upstream --recursive #{repo} #{destination}" unless options[:pretend]
+                     :green
+          system "git clone -q --config push.default=upstream --recursive #{repo} #{destination}"
         end
       end
 
@@ -26,10 +26,10 @@ module Homesick
 
         inside path do
           if path.join('.git').exist?
-            say_status 'git init', 'already initialized', :blue unless options[:quiet]
+            say_status 'git init', 'already initialized', :blue
           else
-            say_status 'git init', '' unless options[:quiet]
-            system 'git init >/dev/null' unless options[:pretend]
+            say_status 'git init', ''
+            system 'git init >/dev/null'
           end
         end
       end
@@ -39,55 +39,55 @@ module Homesick
         existing_remote = nil if existing_remote == ''
 
         if existing_remote
-          say_status 'git remote', "#{name} already exists", :blue unless options[:quiet]
+          say_status 'git remote', "#{name} already exists", :blue
         else
-          say_status 'git remote', "add #{name} #{url}" unless options[:quiet]
-          system "git remote add #{name} #{url}" unless options[:pretend]
+          say_status 'git remote', "add #{name} #{url}"
+          system "git remote add #{name} #{url}"
         end
       end
 
       def git_submodule_init(config = {})
-        say_status 'git submodule', 'init', :green unless options[:quiet]
-        system 'git submodule --quiet init' unless options[:pretend]
+        say_status 'git submodule', 'init', :green
+        system 'git submodule --quiet init'
       end
 
       def git_submodule_update(config = {})
-        say_status 'git submodule', 'update', :green unless options[:quiet]
-        system 'git submodule --quiet update --init --recursive >/dev/null 2>&1' unless options[:pretend]
+        say_status 'git submodule', 'update', :green
+        system 'git submodule --quiet update --init --recursive >/dev/null 2>&1'
       end
 
       def git_pull(config = {})
-        say_status 'git pull', '', :green unless options[:quiet]
-        system 'git pull --quiet' unless options[:pretend]
+        say_status 'git pull', '', :green
+        system 'git pull --quiet'
       end
 
       def git_push(config = {})
-        say_status 'git push', '', :green unless options[:quiet]
-        system 'git push' unless options[:pretend]
+        say_status 'git push', '', :green
+        system 'git push'
       end
 
       def git_commit_all(config = {})
-        say_status 'git commit all', '', :green unless options[:quiet]
+        say_status 'git commit all', '', :green
         if config[:message]
-          system "git commit -a -m '#{config[:message]}'" unless options[:pretend]
+          system "git commit -a -m '#{config[:message]}'"
         else
-          system 'git commit -v -a' unless options[:pretend]
+          system 'git commit -v -a'
         end
       end
 
       def git_add(file, config = {})
-        say_status 'git add file', '', :green unless options[:quiet]
-        system "git add '#{file}'" unless options[:pretend]
+        say_status 'git add file', '', :green
+        system "git add '#{file}'"
       end
 
       def git_status(config = {})
-        say_status 'git status', '', :green unless options[:quiet]
-        system 'git status' unless options[:pretend]
+        say_status 'git status', '', :green
+        system 'git status'
       end
 
       def git_diff(config = {})
-        say_status 'git diff', '', :green unless options[:quiet]
-        system 'git diff' unless options[:pretend]
+        say_status 'git diff', '', :green
+        system 'git diff'
       end
     end
   end

--- a/lib/homesick/cli.rb
+++ b/lib/homesick/cli.rb
@@ -56,14 +56,14 @@ module Homesick
         if homesickrc.exist?
           proceed = shell.yes?("#{name} has a .homesickrc. Proceed with evaling it? (This could be destructive)")
           if proceed
-            shell.say_status 'eval', homesickrc
+            say_status 'eval', homesickrc
             inside destination do
               eval homesickrc.read, binding, homesickrc.expand_path.to_s
             end
           else
-            shell.say_status 'eval skip',
-                             "not evaling #{homesickrc}, #{destination} may need manual configuration",
-                             :blue
+            say_status 'eval skip',
+                       "not evaling #{homesickrc}, #{destination} may need manual configuration",
+                       :blue
           end
         end
       end
@@ -78,7 +78,7 @@ module Homesick
     def pull(name = DEFAULT_CASTLE_NAME)
       if options[:all]
         inside_each_castle do |castle|
-          shell.say castle.to_s.gsub(repos_dir.to_s + '/', '') + ':'
+          say castle.to_s.gsub(repos_dir.to_s + '/', '') + ':'
           update_castle castle
         end
       else
@@ -156,9 +156,9 @@ module Homesick
           target.delete
           mv absolute_path, castle_path
         else
-          shell.say_status(:track,
-                           "#{target} already exists, and is more recent than #{file}. Run 'homesick SYMLINK CASTLE' to create symlinks.",
-                           :blue) unless options[:quiet]
+          say_status(:track,
+                     "#{target} already exists, and is more recent than #{file}. Run 'homesick SYMLINK CASTLE' to create symlinks.",
+                     :blue)
         end
       else
         mv absolute_path, castle_path
@@ -294,9 +294,9 @@ module Homesick
       full_command = args.join(' ')
       say_status "exec '#{full_command}'",
                  "#{options[:pretend] ? 'Would execute' : 'Executing command'} '#{full_command}' in castle '#{castle}'",
-                 :green unless options[:quiet]
+                 :green
       inside repos_dir.join(castle) do
-        system(full_command) unless options[:pretend]
+        system(full_command)
       end
     end
 
@@ -323,8 +323,8 @@ module Homesick
       inside_each_castle do |castle|
         say_status "exec '#{full_command}'",
                    "#{options[:pretend] ? 'Would execute' : 'Executing command'} '#{full_command}' in castle '#{castle}'",
-                   :green unless options[:quiet]
-        system(full_command) unless options[:pretend]
+                   :green
+        system(full_command)
       end
     end
 

--- a/lib/homesick/utils.rb
+++ b/lib/homesick/utils.rb
@@ -2,6 +2,22 @@
 module Homesick
   # Various utility methods that are used by Homesick
   module Utils
+    QUIETABLE = ['say_status']
+
+    PRETENDABLE = ['system']
+
+    QUIETABLE.each do |method_name|
+      define_method(method_name) do |*args|
+        super(*args) unless options[:quiet]
+      end
+    end
+
+    PRETENDABLE.each do |method_name|
+      define_method(method_name) do |*args|
+        super(*args) unless options[:pretend]
+      end
+    end
+
     protected
 
     def home_dir

--- a/spec/homesick_cli_spec.rb
+++ b/spec/homesick_cli_spec.rb
@@ -24,7 +24,7 @@ describe Homesick::CLI do
         end
 
         expect_any_instance_of(Thor::Shell::Basic).to receive(:yes?).with(be_a(String)).and_return(true)
-        expect_any_instance_of(Thor::Shell::Basic).to receive(:say_status).with('eval', kind_of(Pathname))
+        expect(homesick).to receive(:say_status).with('eval', kind_of(Pathname))
         homesick.clone local_repo
 
         expect(castles.join('some_repo').join('testing')).to exist
@@ -129,7 +129,7 @@ describe Homesick::CLI do
           end"
         end
 
-        expect_any_instance_of(Thor::Shell::Basic).to receive(:say_status).with('eval', kind_of(Pathname))
+        expect(homesick).to receive(:say_status).with('eval', kind_of(Pathname))
         homesick.rc castle
 
         expect(castle.join('testing')).to exist
@@ -148,7 +148,7 @@ describe Homesick::CLI do
           end"
         end
 
-        expect_any_instance_of(Thor::Shell::Basic).to receive(:say_status).with('eval skip', /not evaling.+/, :blue)
+        expect(homesick).to receive(:say_status).with('eval skip', /not evaling.+/, :blue)
         homesick.rc castle
 
         expect(castle.join('testing')).not_to exist


### PR DESCRIPTION
- Overrode say_status and system methods to put checks for options[:quiet] and options[:pretend] in one place.
- Edits to make sure that shell.say_status is not called since this does not invoke the overridden say_status method. Edits to tests as a result of this too.
- Removed all uses of 'unless options[:pretend]' and 'unless options[:quiet]' since this is now handled in the overridden methods.
