### PR TITLE
Added basic smoke test

### DIFF
--- a/spec/homesick_cli_spec.rb
+++ b/spec/homesick_cli_spec.rb
@@ -1,6 +1,7 @@
 # -*- encoding : utf-8 -*-
 require 'spec_helper'
 require 'capture-output'
+require 'pathname'
 
 describe Homesick::CLI do
   let(:home) { create_construct }
@@ -11,6 +12,18 @@ describe Homesick::CLI do
   let(:homesick) { Homesick::CLI.new }
 
   before { allow(homesick).to receive(:repos_dir).and_return(castles) }
+
+  describe 'smoke test' do
+    context 'when running bin/homesick' do
+      before do
+        bin_path = Pathname.new(__FILE__).parent.parent
+        @output = `#{bin_path.expand_path}/bin/homesick`
+      end
+      it 'should output some text when bin/homesick is called' do
+        expect(@output.length).to be > 0
+      end
+    end
+  end
 
   describe 'clone' do
     context 'has a .homesickrc' do


### PR DESCRIPTION
Created a basic smoke test to make sure that there is some content produced after calling bin/homesick. Suggested in #109 by @nicolasmccurdy.
