### PR TITLE
Pass destination when cloning url.

### DIFF
--- a/lib/homesick/cli.rb
+++ b/lib/homesick/cli.rb
@@ -50,8 +50,8 @@ module Homesick
           git_clone "https://github.com/#{Regexp.last_match[1]}.git",
                     destination: destination
         elsif uri =~ /%r([^%r]*?)(\.git)?\Z/ || uri =~ /[^:]+:([^:]+)(\.git)?\Z/
-          destination = Pathname.new(Regexp.last_match[1])
-          git_clone uri
+          destination = Pathname.new(Regexp.last_match[1].gsub(/\.git$/,'')).basename
+          git_clone uri, destination: destination
         else
           fail "Unknown URI format: #{uri}"
         end

--- a/spec/homesick_cli_spec.rb
+++ b/spec/homesick_cli_spec.rb
@@ -81,34 +81,39 @@ describe Homesick::CLI do
 
     it 'clones git repo like git://host/path/to.git' do
       expect(homesick).to receive(:git_clone)
-              .with('git://github.com/technicalpickles/pickled-vim.git')
+              .with('git://github.com/technicalpickles/pickled-vim.git',
+                    destination: Pathname.new('pickled-vim'))
 
       homesick.clone 'git://github.com/technicalpickles/pickled-vim.git'
     end
 
     it 'clones git repo like git@host:path/to.git' do
       expect(homesick).to receive(:git_clone)
-              .with('git@github.com:technicalpickles/pickled-vim.git')
+              .with('git@github.com:technicalpickles/pickled-vim.git',
+                    destination: Pathname.new('pickled-vim'))
 
       homesick.clone 'git@github.com:technicalpickles/pickled-vim.git'
     end
 
     it 'clones git repo like http://host/path/to.git' do
       expect(homesick).to receive(:git_clone)
-              .with('http://github.com/technicalpickles/pickled-vim.git')
+              .with('http://github.com/technicalpickles/pickled-vim.git',
+                    destination: Pathname.new('pickled-vim'))
 
       homesick.clone 'http://github.com/technicalpickles/pickled-vim.git'
     end
 
     it 'clones git repo like http://host/path/to' do
       expect(homesick).to receive(:git_clone)
-              .with('http://github.com/technicalpickles/pickled-vim')
+              .with('http://github.com/technicalpickles/pickled-vim',
+                    destination: Pathname.new('pickled-vim'))
 
       homesick.clone 'http://github.com/technicalpickles/pickled-vim'
     end
 
     it 'clones git repo like host-alias:repos.git' do
-      expect(homesick).to receive(:git_clone).with('gitolite:pickled-vim.git')
+      expect(homesick).to receive(:git_clone).with('gitolite:pickled-vim.git',
+                                                   destination: Pathname.new('pickled-vim'))
 
       homesick.clone 'gitolite:pickled-vim.git'
     end


### PR DESCRIPTION
When cloning repositories with ssh aliases, the repository ends up being kind of ugly, e.g. "gitbox:myrepo" rather than just "myrepo".

Just skimming the code, it looks like passing `destination` here (as is simialrly done for github repositories) fixes that. The tests are failing now but I can fix that, just wanted to check if this makes sense first.