### PR TITLE
Add --force option to homesick rc command

### DIFF
--- a/lib/homesick/cli.rb
+++ b/lib/homesick/cli.rb
@@ -61,12 +61,15 @@ module Homesick
     end
 
     desc 'rc CASTLE', 'Run the .homesickrc for the specified castle'
+    method_option :force,
+                  default: false,
+                  desc: 'Evaluate .homesickrc without prompting.'
     def rc(name = DEFAULT_CASTLE_NAME)
       inside repos_dir do
         destination = Pathname.new(name)
         homesickrc = destination.join('.homesickrc').expand_path
         if homesickrc.exist?
-          proceed = shell.yes?("#{name} has a .homesickrc. Proceed with evaling it? (This could be destructive)")
+          proceed = options[:force] || shell.yes?("#{name} has a .homesickrc. Proceed with evaling it? (This could be destructive)")
           if proceed
             say_status 'eval', homesickrc
             inside destination do

--- a/spec/homesick_cli_spec.rb
+++ b/spec/homesick_cli_spec.rb
@@ -149,6 +149,26 @@ describe Homesick::CLI do
       end
     end
 
+    context 'when options[:force] == true' do
+      let(:homesick) { Homesick::CLI.new [], force: true }
+      before do
+        expect_any_instance_of(Thor::Shell::Basic).to_not receive(:yes?)
+      end
+
+      it 'executes the .homesickrc' do
+        castle.file('.homesickrc') do |file|
+          file << "File.open(Dir.pwd + '/testing', 'w') do |f|
+            f.print 'testing'
+          end"
+        end
+
+        expect(homesick).to receive(:say_status).with('eval', kind_of(Pathname))
+        homesick.rc castle
+
+        expect(castle.join('testing')).to exist
+      end
+    end
+
     context 'when told not to do so' do
       before do
         expect_any_instance_of(Thor::Shell::Basic).to receive(:yes?).with(be_a(String)).and_return(false)


### PR DESCRIPTION
Support automatically eval-ing .homesickrc file without prompting for user input.
This is particularly useful for headless scripts that do not support
user input.
