### PR TITLE
Add "requite 'pathname'" to lib/homesick/utils.rb

### DIFF
--- a/lib/homesick/utils.rb
+++ b/lib/homesick/utils.rb
@@ -1,4 +1,6 @@
 # -*- encoding : utf-8 -*-
+require 'pathname'
+
 module Homesick
   # Various utility methods that are used by Homesick
   module Utils


### PR DESCRIPTION
Since Pathname is used in lib/homesick/utils.rb, it should require this module itself.