### PR TITLE
Use source content instead of source path (fixes: #148)

### DIFF
--- a/lib/homesick/utils.rb
+++ b/lib/homesick/utils.rb
@@ -150,7 +150,7 @@ module Homesick
 
     def collision_accepted?(destination, source)
       fail "Arguments must be instances of Pathname, #{destination.class.name} and #{source.class.name} given" unless destination.instance_of?(Pathname) && source.instance_of?(Pathname)
-      options[:force] || shell.file_collision(destination) { source }
+      options[:force] || shell.file_collision(destination) { File.binread(source) }
     end
 
     def each_file(castle, basedir, subdirs)


### PR DESCRIPTION
By reading the source file then passing the content as variable `source`, this commit closes #148.