### PR TITLE
Drop support for Ruby < 2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
+  - 2.3.0
+  - 2.2.0
   - 2.1.0
-  - 2.0.0
-  - 1.9.3
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.2.0
-  - 2.1.0
+  - 2.3.3
+  - 2.2.6
 sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "thor", ">= 0.14.0"
 # Include everything needed to run rake, tests, features, etc.
 group :development do
   gem "rake", ">= 0.8.7"
-  gem "rspec", "~> 3.1.0"
+  gem "rspec", "~> 3.5.0"
   gem "guard"
   gem "guard-rspec"
   gem "rb-readline", "~> 0.5.0"

--- a/README.markdown
+++ b/README.markdown
@@ -164,12 +164,12 @@ and castle
 
 Homesick is tested on the following Ruby versions:
 
-* 1.9.3
-* 2.0.0
 * 2.1.0
+* 2.2.0
+* 2.3.0
 
 ## Note on Patches/Pull Requests
- 
+
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for it. This is important so I don't break it in a future version unintentionally.

--- a/README.markdown
+++ b/README.markdown
@@ -164,9 +164,8 @@ and castle
 
 Homesick is tested on the following Ruby versions:
 
-* 2.1.0
-* 2.2.0
-* 2.3.0
+* 2.2.6
+* 2.3.3
 
 ## Note on Patches/Pull Requests
 

--- a/homesick.gemspec
+++ b/homesick.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<thor>, [">= 0.14.0"])
       s.add_development_dependency(%q<rake>, [">= 0.8.7"])
-      s.add_development_dependency(%q<rspec>, ["~> 3.1.0"])
+      s.add_development_dependency(%q<rspec>, ["~> 3.5.0"])
       s.add_development_dependency(%q<guard>, [">= 0"])
       s.add_development_dependency(%q<guard-rspec>, [">= 0"])
       s.add_development_dependency(%q<rb-readline>, ["~> 0.5.0"])
@@ -66,7 +66,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<thor>, [">= 0.14.0"])
       s.add_dependency(%q<rake>, [">= 0.8.7"])
-      s.add_dependency(%q<rspec>, ["~> 3.1.0"])
+      s.add_dependency(%q<rspec>, ["~> 3.5.0"])
       s.add_dependency(%q<guard>, [">= 0"])
       s.add_dependency(%q<guard-rspec>, [">= 0"])
       s.add_dependency(%q<rb-readline>, ["~> 0.5.0"])
@@ -79,7 +79,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<thor>, [">= 0.14.0"])
     s.add_dependency(%q<rake>, [">= 0.8.7"])
-    s.add_dependency(%q<rspec>, ["~> 3.1.0"])
+    s.add_dependency(%q<rspec>, ["~> 3.5.0"])
     s.add_dependency(%q<guard>, [">= 0"])
     s.add_dependency(%q<guard-rspec>, [">= 0"])
     s.add_dependency(%q<rb-readline>, ["~> 0.5.0"])
@@ -90,4 +90,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<rubocop>, [">= 0"])
   end
 end
-

--- a/spec/homesick_cli_spec.rb
+++ b/spec/homesick_cli_spec.rb
@@ -146,7 +146,7 @@ describe Homesick::CLI do
 
     it 'throws an exception when trying to clone a malformed uri like malformed' do
       expect(homesick).not_to receive(:git_clone)
-      expect { homesick.clone 'malformed' }.to raise_error
+      expect { homesick.clone 'malformed' }.to raise_error(RuntimeError)
     end
 
     it 'clones a github repo' do


### PR DESCRIPTION
I think it makes sense to drop the support for Ruby 1.9.3, 2.0.0 and 2.1.0

| Version | End of support phase | End of security maintenance phase |
| ------- | ---------------------- | ----------------------------------- | 
| Ruby 1.9.3 | 2014-02-23 | 2015-02-23 |
| Ruby 2.0.0 | 2015-02-24 | 2016-02-24 |
| Ruby 2.1.0 | 2016-03-30 | 2017-03-30 |

Add the support for the Ruby 2.2.6 and 2.3.3