### PR TITLE
Use real paths of symlinks when linking castle into home

### DIFF
--- a/lib/homesick/actions/file_actions.rb
+++ b/lib/homesick/actions/file_actions.rb
@@ -42,7 +42,7 @@ module Homesick
       end
 
       def ln_s(source, destination)
-        source = Pathname.new(source)
+        source = Pathname.new(source).realpath        
         destination = Pathname.new(destination)
         FileUtils.mkdir_p destination.dirname
 


### PR DESCRIPTION
The problem is the following: one may want to use _selected_ files from external git modules in castle structure. Good example is vim colour schemes. Consider the following structure of the castle repo:

```
castle
|-- home
|   `-- .vim
|       `-- colors
|            `-- solarized.vim -> ../../modules/vim-solarized/colors/solarized.vim
`-- modules
    `-- colors
        `-- solarized.vim
```

Currently ```homesick link``` of such castle will result in getting the broken links in ```~/.vim/colors```:

```
~
`-- .vim
    `-- colors
         `-- solarized.vim -> ../../modules/vim-solarized/colors/solarized.vim
```

Proposed trivial patch will link original files from castle structure, resulting in following:

```
~
`-- .vim
    `-- colors
         `-- solarized.vim -> ~/.homesick/repos/castle/modules/vim-solarized/colors/solarized.vim
```
