### PR TITLE
Fix "diff" action on binary files

### DIFF
--- a/lib/homesick/cli.rb
+++ b/lib/homesick/cli.rb
@@ -27,13 +27,13 @@ module Homesick
       # Hack in support for diffing symlinks
       # Also adds support for checking if destination or content is a directory
       shell_metaclass = class << shell; self; end
-      shell_metaclass.send(:define_method, :show_diff) do |destination, content|
+      shell_metaclass.send(:define_method, :show_diff) do |destination, source|
         destination = Pathname.new(destination)
-        content = Pathname.new(content)
-        return 'Unable to create diff: destination or content is a directory' if destination.directory? || content.directory?
-        return super(destination, content) unless destination.symlink?
+        source = Pathname.new(source)
+        return 'Unable to create diff: destination or content is a directory' if destination.directory? || source.directory?
+        return super(destination, source) unless destination.symlink?
         say "- #{destination.readlink}", :red, true
-        say "+ #{content.expand_path}", :green, true
+        say "+ #{source.expand_path}", :green, true
       end
     end
 

--- a/lib/homesick/cli.rb
+++ b/lib/homesick/cli.rb
@@ -31,7 +31,7 @@ module Homesick
         destination = Pathname.new(destination)
         source = Pathname.new(source)
         return 'Unable to create diff: destination or content is a directory' if destination.directory? || source.directory?
-        return super(destination, source) unless destination.symlink?
+        return super(destination, File.binread(source)) unless destination.symlink?
         say "- #{destination.readlink}", :red, true
         say "+ #{source.expand_path}", :green, true
       end

--- a/lib/homesick/utils.rb
+++ b/lib/homesick/utils.rb
@@ -150,7 +150,7 @@ module Homesick
 
     def collision_accepted?(destination, source)
       fail "Arguments must be instances of Pathname, #{destination.class.name} and #{source.class.name} given" unless destination.instance_of?(Pathname) && source.instance_of?(Pathname)
-      options[:force] || shell.file_collision(destination) { File.binread(source) }
+      options[:force] || shell.file_collision(destination) { source }
     end
 
     def each_file(castle, basedir, subdirs)


### PR DESCRIPTION
The previous patch I made fixing #148 breaks the "link -> d" action on binary files, making the `Pathname.new(content)` on `cli.rb:32` fails with an exception `ArgumentError(pathname contains null byte)`.

Thus, I 
1. revert commit ed397bdaf8ccde86a4b39863f2b68254f8a5c9bc, and
2. rename the local variable `content` to `source`, and
3. put the `File.binread` to the correct place.