### PR TITLE
Conform to the XDG Base Directory Specification

### DIFF
--- a/lib/homesick/utils.rb
+++ b/lib/homesick/utils.rb
@@ -9,8 +9,12 @@ module Homesick
       @home_dir ||= Pathname.new(ENV['HOME'] || '~').realpath
     end
 
+    def xdg_data_dir
+      @xdg_data_dir ||= Pathname.new(ENV['XDG_DATA_HOME'] || home_dir.join('.local', 'share')).realpath
+    end
+
     def repos_dir
-      @repos_dir ||= home_dir.join('.homesick', 'repos').expand_path
+      @repos_dir ||= xdg_data_dir.join('homesick', 'repos').expand_path
     end
 
     def castle_dir(name)

--- a/spec/homesick_cli_spec.rb
+++ b/spec/homesick_cli_spec.rb
@@ -6,7 +6,7 @@ describe Homesick::CLI do
   let(:home) { create_construct }
   after { home.destroy! }
 
-  let(:castles) { home.directory('.homesick/repos') }
+  let(:castles) { home.directory('.local/share/homesick/repos') }
 
   let(:homesick) { Homesick::CLI.new }
 
@@ -104,7 +104,7 @@ describe Homesick::CLI do
       Capture.stderr do
         homesick.clone "file://#{bare_repo}"
       end
-      expect(File.directory?(File.join(home.to_s, '.homesick/repos/dotfiles')))
+      expect(File.directory?(File.join(home.to_s, '.local/share/homesick/repos/dotfiles')))
         .to be_truthy
     end
 


### PR DESCRIPTION
The [XDG Base Directory Specification] aims to provide guidelines for organizing configuration, data and cache files for a system. Some of the benefits include a less cluttered home directory, easy backups and predictability. This commit changes the default directory for homsick castles to be `XDG_DATA_HOME/homesick` instead of `~/.homesick`.

[XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html

## Alternative

An alternative could be to provide a environment variable (e.g `HOMESICK_CASTLE_DIR`) which would be used to store the cloned castles. This could be defaulted to `.homesick` to enable backwards compatibility.