### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,8 @@ rvm:
   - 2.4.0
   - 2.3.3
   - 2.2.6
+matrix:
+  exclude:
+  - arch: ppc64le
+    rvm: 2.2.6  
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
 language: ruby
 rvm:
   - 2.5.0


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
Exclude ruby 2.2.6 for ppc64le as it could not found for installation.
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3