### PR TITLE
Fix #177: respect --pretend flag in all destructive file actions

### DIFF
--- a/lib/homesick/actions/file_actions.rb
+++ b/lib/homesick/actions/file_actions.rb
@@ -16,7 +16,7 @@ module Homesick
 
       def rm_rf(dir)
         say_status "rm -rf #{dir}", '', :green
-        FileUtils.rm_r dir, force: true
+        FileUtils.rm_r dir, force: true unless options[:pretend]
       end
 
       def rm_link(target)
@@ -24,7 +24,7 @@ module Homesick
 
         if target.symlink?
           say_status :unlink, target.expand_path.to_s, :green
-          FileUtils.rm_rf target
+          FileUtils.rm_rf target unless options[:pretend]
         else
           say_status :conflict, "#{target} is not a symlink", :red
         end
@@ -32,12 +32,12 @@ module Homesick
 
       def rm(file)
         say_status "rm #{file}", '', :green
-        FileUtils.rm file, force: true
+        FileUtils.rm file, force: true unless options[:pretend]
       end
 
       def rm_r(dir)
         say_status "rm -r #{dir}", '', :green
-        FileUtils.rm_r dir
+        FileUtils.rm_r dir unless options[:pretend]
       end
 
       def ln_s(source, destination)

--- a/lib/homesick/utils.rb
+++ b/lib/homesick/utils.rb
@@ -207,17 +207,18 @@ module Homesick
       absolute_basedir = Pathname.new(basedir).expand_path
       castle_home = castle_dir(castle)
       inside basedir do |destination_root|
-        FileUtils.cd(destination_root) unless destination_root == FileUtils.pwd
-        files = Pathname.glob('*', File::FNM_DOTMATCH)
-                        .reject { |a| ['.', '..'].include?(a.to_s) }
-                        .reject { |path| matches_ignored_dir? castle_home, path.expand_path, subdirs }
-        files.each do |path|
-          absolute_path = path.expand_path
+        FileUtils.cd(destination_root) do
+          files = Pathname.glob('*', File::FNM_DOTMATCH)
+                          .reject { |a| ['.', '..'].include?(a.to_s) }
+                          .reject { |path| matches_ignored_dir? castle_home, path.expand_path, subdirs }
+          files.each do |path|
+            absolute_path = path.expand_path
 
-          relative_dir = absolute_basedir.relative_path_from(castle_home)
-          home_path = home_dir.join(relative_dir).join(path)
+            relative_dir = absolute_basedir.relative_path_from(castle_home)
+            home_path = home_dir.join(relative_dir).join(path)
 
-          yield(absolute_path, home_path)
+            yield(absolute_path, home_path)
+          end
         end
       end
     end

--- a/spec/homesick_cli_spec.rb
+++ b/spec/homesick_cli_spec.rb
@@ -710,6 +710,48 @@ describe Homesick::CLI do
 
       expect(castle).not_to be_exist
     end
+
+    context 'pretend' do
+      it 'does not remove symlink files' do
+        expect_any_instance_of(Thor::Shell::Basic).to receive(:yes?).and_return('y')
+        given_castle('stronghold')
+        some_rc_file = home.file '.some_rc_file'
+        homesick.track(some_rc_file.to_s, 'stronghold')
+        Capture.stdout { homesick.invoke 'destroy', ['stronghold'], pretend: true }
+        expect(home.join('.some_rc_file')).to be_exist
+      end
+
+      it 'does not delete the cloned repository' do
+        expect_any_instance_of(Thor::Shell::Basic).to receive(:yes?).and_return('y')
+        given_castle('stronghold')
+        some_rc_file = home.file '.some_rc_file'
+        homesick.track(some_rc_file.to_s, 'stronghold')
+        Capture.stdout { homesick.invoke 'destroy', ['stronghold'], pretend: true }
+        expect(castles.join('stronghold')).to be_exist
+      end
+    end
+  end
+
+  describe 'file actions' do
+    context 'pretend' do
+      describe '#rm' do
+        it 'does not remove the file' do
+          test_file = home.file('test_file')
+          allow(homesick).to receive(:options).and_return(pretend: true)
+          expect(FileUtils).not_to receive(:rm)
+          homesick.send(:rm, test_file)
+        end
+      end
+
+      describe '#rm_r' do
+        it 'does not remove the directory' do
+          test_dir = home.directory('test_dir')
+          allow(homesick).to receive(:options).and_return(pretend: true)
+          homesick.send(:rm_r, test_dir)
+          expect(test_dir).to be_exist
+        end
+      end
+    end
   end
 
   describe 'cd' do


### PR DESCRIPTION
rm_rf, rm_link, rm, and rm_r were calling FileUtils unconditionally, ignoring options[:pretend]. This caused `homesick destroy --pretend` to actually delete the castle and its symlinks instead of doing a dry run.

Fixes #177 

https://claude.ai/code/session_01YCwmQwLcoLBGjQ8yXWQ7pd