### PR TITLE
Change CI ordering to run RuboCop before tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
           git config --global user.email "test@example.com"
           git config --global user.name "Test User"
 
-      - name: Run tests
-        run: bundle exec rspec
-
       - name: Run RuboCop
         run: bundle exec rubocop
+
+      - name: Run tests
+        run: bundle exec rspec
 
       - name: Audit dependencies
         run: |


### PR DESCRIPTION
Change ordering to run static analysis before tests since there's no point in continuing if that fails.