### PR TITLE
restore link idempotency

### DIFF
--- a/lib/homesick/actions/file_actions.rb
+++ b/lib/homesick/actions/file_actions.rb
@@ -45,10 +45,15 @@ module Homesick
         destination = Pathname.new(destination)
         FileUtils.mkdir_p destination.dirname
 
-        action = :success
-        action = :identical if destination.symlink? && destination.readlink == source
-        action = :symlink_conflict if destination.symlink?
-        action = :conflict if destination.exist?
+        action = if destination.symlink? && destination.readlink == source
+                   :identical
+                 elsif destination.symlink?
+                   :symlink_conflict
+                 elsif destination.exist?
+                   :conflict
+                 else
+                   :success
+                 end
 
         handle_symlink_action action, source, destination
       end

--- a/spec/homesick_cli_spec.rb
+++ b/spec/homesick_cli_spec.rb
@@ -255,6 +255,19 @@ describe Homesick::CLI do
       expect(home.join('bin').readlink).to eq(dotfile)
     end
 
+    context 'when the symlink is already in place' do
+      it 'does not prompt for collision on subsequent runs' do
+        dotfile = castle.file('.some_dotfile')
+
+        homesick.link('glencairn')
+
+        expect(homesick.shell).not_to receive(:file_collision)
+        homesick.link('glencairn')
+
+        expect(home.join('.some_dotfile').readlink).to eq(dotfile)
+      end
+    end
+
     context 'when a conflict exists' do
       it 'does not replace the existing file when collision is declined' do
         dotfile = castle.file('.some_dotfile')


### PR DESCRIPTION
This fixes a regression where you will always be prompted to overwrite an identical symlink.

To reproduce the issue run the new spec but without the fix. 

