### PR TITLE
Respect `HOMESICKDIR` env for data directory

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ Metrics/MethodLength:
   Max: 25
 
 Metrics/ModuleLength:
-  Max: 210
+  Max: 213
 
 Metrics/ParameterLists:
   Max: 6

--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@
 
 Your home directory is your castle. Don't leave your dotfiles behind.
 
-Homesick is sorta like [rip](http://github.com/defunkt/rip), but for dotfiles. It uses git to clone a repository containing dotfiles, and saves them in `~/.homesick`. It then allows you to symlink all the dotfiles into place with a single command.
+Homesick is sorta like [rip](http://github.com/defunkt/rip), but for dotfiles. It uses git to clone a repository containing dotfiles, and saves them in `~/.homesick`. It then allows you to symlink all the dotfiles into place with a single command. (Set the `HOMESICKDIR` environment variable if you'd like to use a different location instead of `~/.homesick`.)
 
 We call a repository that is compatible with homesick to be a 'castle'. To act as a castle, a repository must be organized like so:
 

--- a/lib/homesick/utils.rb
+++ b/lib/homesick/utils.rb
@@ -11,8 +11,14 @@ module Homesick
       @home_dir ||= Pathname.new(Dir.home).realpath
     end
 
+    def data_dir
+      ENV.fetch('HOMESICKDIR', nil).then do |path|
+        path ? Pathname(path).expand_path : home_dir.join('.homesick')
+      end
+    end
+
     def repos_dir
-      @repos_dir ||= home_dir.join('.homesick', 'repos').expand_path
+      @repos_dir ||= data_dir.join('repos').expand_path
     end
 
     def castle_dir(name)

--- a/spec/homesick_utils_spec.rb
+++ b/spec/homesick_utils_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+class DummyHomesick
+  include Homesick::Utils
+
+  def public_repos_dir = repos_dir
+end
+
+describe Homesick::Utils do
+  around do |example|
+    original_envs = ENV.slice('HOME', 'HOMESICKDIR')
+    ENV.merge!({ 'HOME' => home.to_s, 'HOMESICKDIR' => homesickdir })
+
+    example.run
+
+    ENV.merge!(original_envs)
+    home.destroy!
+  end
+
+  let(:home) { create_construct }
+  let(:homesick) { DummyHomesick.new }
+  let(:homesickdir) { nil }
+
+  context 'when HOMESICKDIR not set' do
+    describe '#repos_dir' do
+      it 'defaults to ~/.homesick' do
+        expect(homesick.public_repos_dir).to eq(Pathname("#{home}/.homesick/repos"))
+      end
+    end
+  end
+
+  context 'when custom HOMESICKDIR is set' do
+    let(:homesickdir) { '/custom-dir' }
+
+    describe '#repos_dir' do
+      it 'uses HOMESICKDIR' do
+        expect(homesick.public_repos_dir).to eq(Pathname('/custom-dir/repos'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Gives users the option to put the homesick data directory somewhere other than the home dir, for example `~/.local/share/homesick`.

I'm on a mission to clear all the dotfiles out of my home directory, a hopeless task, I wish I'd never started 😅

Only a small update to the readme, as this is probably a niche feature.