### PR TITLE
Indicate when in Homesick shell

### DIFF
--- a/lib/homesick/cli.rb
+++ b/lib/homesick/cli.rb
@@ -237,7 +237,8 @@ module Homesick
                  "Opening a new shell in castle '#{castle}'. To return to the original one exit from the new shell.",
                  :green
       inside castle_dir do
-        system(ENV.fetch('SHELL', nil))
+        shell = ENV.fetch('SHELL', nil)
+        system("HOMESICK_SHELL=1 #{shell}") if shell
       end
     end
 


### PR DESCRIPTION
Set env var after `homesick cd`. This allows custom prompts to add a visual indicator that are in a shell within a shell.

I often `homesick cd` into my dotfiles, and then move around directory a couple of times, and I can't remember if I'm in a subshell or not. This means that `exit` may or may not do what I think it will. By setting `HOMESICK_SHELL` when inside the sub-shell I can add it to my custom prompt:

<img width="700" alt="image" src="https://github.com/user-attachments/assets/2342e406-e043-4733-8bfd-2791482af82f" />
